### PR TITLE
Add sphere mesh generator

### DIFF
--- a/Engine.elm
+++ b/Engine.elm
@@ -63,10 +63,10 @@ changed and removes any unnecessary boilerplate.
 @docs MaterialProperty, Material, material
 
 # Mesh
-@docs Mesh, triangleMesh, rectangleMesh, pyramidMesh, cubeMesh
+@docs Mesh, triangleMesh, rectangleMesh, pyramidMesh, cubeMesh, sphereMesh
 
 # Renderable
-@docs Renderable, renderable, triangle, rectangle, pyramid, cube
+@docs Renderable, renderable, triangle, rectangle, pyramid, cube, sphere
 
 # Render Function
 @docs render
@@ -98,6 +98,7 @@ import Engine.Mesh.Triangle             as Triangle
 import Engine.Mesh.Rectangle            as Rectangle
 import Engine.Mesh.Cube                 as Cube
 import Engine.Mesh.Pyramid              as Pyramid
+import Engine.Mesh.Sphere               as Sphere
 import Engine.Shader.Attribute          as Attribute
 import Engine.Shader.Uniform            as Uniform
 import Engine.Render.Render             as Render
@@ -383,6 +384,25 @@ returns a pyramid mesh.
 -}
 pyramidMesh : Vec3 -> Float -> Float -> Mesh
 pyramidMesh = Pyramid.pyramidMesh
+
+----------------------------------------------------------------------------
+
+----------------- Re-export Engine.Mesh.Sphere -----------------------------
+
+{-| Default sphere renderable object. Located at the origin with radius of 0.5.
+-}
+
+sphere : Renderable
+sphere = Sphere.sphere
+
+{-| Function that takes a center point/vector, the radius, the number of
+segments around the sphere radially (like longitude), the number of segments up
+and down (like latitude), and returns a mesh that approximates a sphere.
+
+    sphereMesh center radius segmentsR segmentsY
+-}
+sphereMesh : Vec3 -> Float -> Float -> Float -> Mesh
+sphereMesh = Sphere.sphereMesh
 
 ----------------------------------------------------------------------------
 

--- a/Engine/Mesh/Sphere.elm
+++ b/Engine/Mesh/Sphere.elm
@@ -1,0 +1,58 @@
+module Engine.Mesh.Sphere where
+
+{-| This module contains the definition of a sphere mesh and of a sphere
+renderable object.
+
+# Sphere Mesh
+@docs sphereMesh
+
+# Sphere (Renderable)
+@docs sphere
+
+-}
+
+import List
+
+import Math.Vector3 (Vec3, add, vec3)
+import Engine.Mesh.Mesh (Mesh)
+import Engine.Mesh.Rectangle (rectangleMesh)
+import Engine.Mesh.Triangle (triangleMesh, triangle)
+import Engine.Render.Renderable (Renderable)
+
+
+{-| Function that takes a center point/vector, the radius, the number of
+segments around the sphere radially (like longitude), the number of segments up
+and down (like latitude), and returns a mesh that approximates a sphere.
+
+      sphere center segmentsR segmentsY
+-}
+sphereMesh : Vec3 -> Float -> Float -> Float -> Mesh
+sphereMesh center radius segmentsR segmentsY = let
+    dt = 2 * pi / segmentsR
+    dy = 1 / segmentsY
+    halfRadius = radius / 2
+    getRadius y = sqrt (max 0 (halfRadius - y*y))
+  in [0..segmentsR-1] |> List.concatMap (\i -> let
+        theta = i * dt
+        x0 = cos theta
+        x1 = cos (theta + dt)
+        z0 = sin theta
+        z1 = sin (theta + dt)
+    in [0..segmentsY-1] |> List.concatMap (\j -> let
+          y0 = j*dy - radius
+          y1 = y0+dy
+          r0 = getRadius y0
+          r1 = getRadius y1
+          bl = center `add` (vec3 (x0*r0) y0 (z0*r0))
+          br = center `add` (vec3 (x1*r0) y0 (z1*r0))
+          tl = center `add` (vec3 (x0*r1) y1 (z0*r1))
+          tr = center `add` (vec3 (x1*r1) y1 (z1*r1))
+        in triangleMesh bl br tr ++ triangleMesh bl tr tl))
+        -- in rectangleMesh bl br tl tr))
+
+
+{-| Default sphere renderable object. Located at the origin with radius of 0.5.
+-}
+sphere : Renderable
+sphere = {
+  triangle | mesh <- sphereMesh (vec3 0 0 0) 0.5 20 20 }

--- a/README.md
+++ b/README.md
@@ -169,12 +169,16 @@ type alias Attribute = {
 
 Typically, one would send a color and a normal attribute to the GPU. But, the choice made by the library is that normals can be calculated by passing in a normal matrix and color can be set on the `Material`
 
-The library offers currently 4 basic meshes to construct your objects:
+The library offers some basic meshes to construct your objects. In 2D:
+
+ * `rectangleMesh`
+ * `triangleMesh`
+
+And in 3D:
 
  * `cubeMesh`
  * `pyramidMesh`
- * `rectangleMesh`
- * `triangleMesh`
+ * `sphereMesh`
 
 -----------------------------------
 ##Material##

--- a/elm-package.json
+++ b/elm-package.json
@@ -17,6 +17,7 @@
         "Engine.Mesh.Rectangle",
         "Engine.Mesh.Pyramid",
         "Engine.Mesh.Cube",
+        "Engine.Mesh.Sphere",
         "Engine.Render.Renderable",
         "Engine.Render.DefaultRenderable",
         "Engine.Render.Render",


### PR DESCRIPTION
Add a function to create a mesh that approximates a sphere. The code is ported (pretty directly, surprisingly enough) from some C++ I wrote in a college graphics course. We approximate a sphere by a parametric number of segments radially and vertically, with each r,y segment pair becoming a quad. I have some more primitives from that college course which I can discuss if you like the sphere.

Some other things I noticed working with the library:
- The default red material is really garish. We should use a gray instead, but this is only a minor improvement until we make the lighting less washed out, so you can see which surfaces are further away from you.
- Possibly relatedly, how are normals handled? I saw something about a normal matrix but I don't really understand it. In my course, we determined the normals along with the coordinates in the meshes, and then used those for lighting.
- In my (limited) experience and according to John Mayer's [writeup](http://package.elm-lang.org/packages/johnpmayer/elm-webgl/1.0.0), meshes are expensive. They should be centered on the origin (at unit size), so you send them to the graphics card _once_. Then you do your affine transformations in shaders, or in our case, by modifying the records. Incidentally, the Renderable docs seem to be out of date regarding where these transforms are stored...
- Is there a perspective camera or is that in the works?
- There's something weird going on with `rectangleMesh`. I used two calls to `triangleMesh` and it works, but if you switch the commend some of the triangles don't render. Originally I thought this was because the triangles were facing the wrong way but apparently not. This will require some thought and/or googling.
- A flowchart showing how all of these record types integrate may be helpful.
- I never thought I'd see a project that's too modular or too well-documented, but this might fit the bill. Everything is so spread out that it's hard to see where the magic actually happens. This necessitates the reexports in `Engine.elm`, which duplicates the documentation. Then it's all there again in the README. Keeping it all synced is a timesuck and it keeps the developer from getting to the meat of the project.
- You should add `elm.js` and `elm-stuff` to a `.gitignore` as they are generated files.
