### PR TITLE
Build is broken. Made correction in elm-package.json for johnpmayer/elm-linear-algebra depdncy.

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -34,7 +34,7 @@
     ],
     "dependencies": {
         "elm-lang/core": "1.0.0 <= v < 2.0.0",
-        "johnpmayer/elm-linear-algebra": "1.0.0 <= v < 2.0.0",
+        "johnpmayer/elm-linear-algebra": "2.0.0 <= v < 3.0.0",
         "johnpmayer/elm-webgl": "1.0.0 <= v < 2.0.0"
     }
 }


### PR DESCRIPTION
Hello, the dependency.son had an error which was breaking the installation of your package. It became inconsistent when johmpmayer bumped his packages versions for elm-webgl.

Correcting Dependency Tree. Previous version constraint for johnpmayer/elm-linear-algebra conflicted with expected version from johnpmayer/elm-webgl.
